### PR TITLE
[FIX] update name package octave-dev

### DIFF
--- a/.github/workflows/run_tests_octave.yml
+++ b/.github/workflows/run_tests_octave.yml
@@ -45,7 +45,7 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get -y install \
           octave \
-          liboctave-dev\
+          octave-dev\
           octave-common \
           octave-io \
           octave-image \


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the installed Octave package name to octave-dev.